### PR TITLE
Change to Graphite detection.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="/clients/main/favicon.ico" />
-    <link rel="stylesheet" href="/webfonts/_webfonts.css">
+    <link rel="stylesheet" href="/webfonts/_webfonts.css" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Pankosmia Editor" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@mui/icons-material": "^7.0.1",
         "@mui/material": "^7.0.0",
         "eslint-config-react-app": "^7.0.1",
+        "font-detect-rhl": "^1.1.7",
         "json-edit-react": "^1.25.0",
         "pithekos-lib": "^0.10.3",
         "react": "^17.0.0 || ^18.0.0",
@@ -7394,6 +7395,14 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/destroy": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
@@ -8959,6 +8968,22 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/font-detect-rhl": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/font-detect-rhl/-/font-detect-rhl-1.1.7.tgz",
+      "integrity": "sha512-2HbmAPVJCd1u1ddNqJzFUXyYLvHN8ZnmGLL7cduR57mBr1dI9fPwyXZ9x/OLs58H7uP/lmeqqmHyTl2XefKoWQ==",
+      "dependencies": {
+        "prop-types": "^15.6.1",
+        "use-deep-compare": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/for-each": {
@@ -17477,6 +17502,17 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-deep-compare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-deep-compare/-/use-deep-compare-1.3.0.tgz",
+      "integrity": "sha512-94iG+dEdEP/Sl3WWde+w9StIunlV8Dgj+vkt5wTwMoFQLaijiEZSXXy8KtcStpmEDtIptRJiNeD4ACTtVvnIKA==",
+      "dependencies": {
+        "dequal": "2.0.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@mui/icons-material": "^7.0.1",
     "@mui/material": "^7.0.0",
     "eslint-config-react-app": "^7.0.1",
+    "font-detect-rhl": "^1.1.7",
     "json-edit-react": "^1.25.0",
     "pithekos-lib": "^0.10.3",
     "react": "^17.0.0 || ^18.0.0",

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="/clients/main/favicon.ico" />
-    <link rel="stylesheet" href="/webfonts/_webfonts.css">
+    <link rel="stylesheet" href="/webfonts/_webfonts.css" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,8 +2,8 @@ import {useState, useCallback, useEffect, useContext} from 'react';
 import {Box, Button} from "@mui/material";
 import {JsonEditor} from 'json-edit-react'
 import {getAndSetJson, postJson, debugContext, i18nContext, typographyContext, SpSpaPage, doI18n} from "pithekos-lib";
-import {useDetectRender} from 'font-detect-rhl';
 import {IconAdd, IconClose, IconDelete, IconDone, IconEdit} from "./icons";
+import GraphiteTest from './components/GraphiteTest';
 
 function App() {
     const {debugRef} = useContext(debugContext);
@@ -29,10 +29,9 @@ function App() {
         []
     );
 
-    const testFont = [{ name: 'Pankosmia-Awami Nastaliq for Graphite Test' }];
-    const renderType = useDetectRender({fonts:testFont});
-    const isGraphite = (renderType[0].detectedRender === 'RenderingGraphite')
-    const selectedFontClass = isGraphite ? typographyRef.current.font_set : typographyRef.current.font_set.replace(/Pankosmia-AwamiNastaliq(.*)Pankosmia-NotoNastaliqUrdu/ig, 'Pankosmia-NotoNastaliqUrdu');
+    const isGraphite = GraphiteTest()
+    /** adjSelectedFontClass is reshaped for the presence or absence of Graphite. */
+    const adjSelectedFontClass = isGraphite ? typographyRef.current.font_set : typographyRef.current.font_set.replace(/Pankosmia-AwamiNastaliq(.*)Pankosmia-NotoNastaliqUrdu/ig, 'Pankosmia-NotoNastaliqUrdu');
  
     useEffect(() => {
         window.addEventListener('resize', handleWindowResize);
@@ -76,7 +75,7 @@ function App() {
         titleKey="pages:i18n-editor:title"
         currentId="i18n-editor"
     >
-        <Box sx={{maxHeight: maxWindowHeight}} className={selectedFontClass}>
+        <Box sx={{maxHeight: maxWindowHeight}} className={adjSelectedFontClass}>
             {i18nRef.current["pages:i18n-editor:single_translation"] &&
             <JsonEditor
                 data={i18nData}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,7 +30,7 @@ function App() {
     );
 
     const isGraphite = GraphiteTest()
-    /** adjSelectedFontClass is reshaped for the presence or absence of Graphite. */
+    /** adjSelectedFontClass reshapes selectedFontClass if Graphite is absent. */
     const adjSelectedFontClass = isGraphite ? typographyRef.current.font_set : typographyRef.current.font_set.replace(/Pankosmia-AwamiNastaliq(.*)Pankosmia-NotoNastaliqUrdu/ig, 'Pankosmia-NotoNastaliqUrdu');
  
     useEffect(() => {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,15 +1,16 @@
 import {useState, useCallback, useEffect, useContext} from 'react';
 import {Box, Button} from "@mui/material";
 import {JsonEditor} from 'json-edit-react'
-import {getAndSetJson, postJson, debugContext, i18nContext, SpSpaPage, doI18n} from "pithekos-lib";
+import {getAndSetJson, postJson, debugContext, i18nContext, typographyContext, SpSpaPage, doI18n} from "pithekos-lib";
+import {useDetectRender} from 'font-detect-rhl';
 import {IconAdd, IconClose, IconDelete, IconDone, IconEdit} from "./icons";
 
 function App() {
     const {debugRef} = useContext(debugContext);
     const {i18nRef} = useContext(i18nContext);
+    const { typographyRef } = useContext(typographyContext);
     const [i18nData, setI18nData] = useState({});
     const [unsavedData, setUnsavedData] = useState(false);
-    const [fontClass, setFontClass] = useState([]);
     const [maxWindowHeight, setMaxWindowHeight] = useState(window.innerHeight - 80);
 
     const handleWindowResize = useCallback(event => {
@@ -28,16 +29,11 @@ function App() {
         []
     );
 
-    useEffect(
-        () => {
-            getAndSetJson({
-                url: "/settings/typography",
-                setter: setFontClass
-            }).then()
-        },
-        []
-    );
-
+    const testFont = [{ name: 'Pankosmia-Awami Nastaliq for Graphite Test' }];
+    const renderType = useDetectRender({fonts:testFont});
+    const isGraphite = (renderType[0].detectedRender === 'RenderingGraphite')
+    const selectedFontClass = isGraphite ? typographyRef.current.font_set : typographyRef.current.font_set.replace(/Pankosmia-AwamiNastaliq(.*)Pankosmia-NotoNastaliqUrdu/ig, 'Pankosmia-NotoNastaliqUrdu');
+ 
     useEffect(() => {
         window.addEventListener('resize', handleWindowResize);
         return () => {
@@ -49,7 +45,7 @@ function App() {
         styles: {
             container: {
                 backgroundColor: 'inherited',
-                fontFamily: 'inherited',
+                fontFamily: '',
                 fontSize: "xx-large",
                 color: "#441650"
             },
@@ -80,7 +76,7 @@ function App() {
         titleKey="pages:i18n-editor:title"
         currentId="i18n-editor"
     >
-        <Box sx={{maxHeight: maxWindowHeight}} className={fontClass.font_set}>
+        <Box sx={{maxHeight: maxWindowHeight}} className={selectedFontClass}>
             {i18nRef.current["pages:i18n-editor:single_translation"] &&
             <JsonEditor
                 data={i18nData}

--- a/src/components/GraphiteTest.jsx
+++ b/src/components/GraphiteTest.jsx
@@ -1,0 +1,34 @@
+import { useState, useEffect } from 'react';
+import {useDetectRender} from 'font-detect-rhl';
+
+export default function GraphiteTest() {
+
+  const [testFont, setTestFont] = useState('');
+  const [hasRunOnce, setHasRunOnce] = useState(false);
+
+  const font = new FontFace("Pankosmia-GraphiteTest", "url(/webfonts/awami/AwamiNastaliq-Regular.woff2)", {
+    style: "normal",
+    weight: "normal",
+  });
+
+  document.fonts.add(font);
+  
+  async function check() {
+    await font.load();
+    setTestFont('Pankosmia-GraphiteTest');
+  }
+
+  useEffect ( () => {
+    if (!hasRunOnce) {
+      check();
+      setHasRunOnce(true);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  },[hasRunOnce])
+
+  const testFontArray = [{ name: testFont }];
+  const renderType = useDetectRender({fonts:testFontArray});
+  const isGraphite = renderType[0].detectedRender === 'RenderingGraphite';
+
+  return isGraphite;
+}


### PR DESCRIPTION
### This PR is for use in conjunction with or before the planned Electronite version of Liminal.
- Instead detecting the presence of Firefox, this upgrade detects when Graphite rendering exists, whatever the client.

### Important: Please accept "Change to Graphite detection." PRs on the following repos at the same time:
- core-client-settings
- core-client-workspace 
- core-client-content
- core-client-i18n-editor 
- webfonts-core: _Contains new font classes in support of the changes above._
- pankosmia-web: _keeping 1 version of font "truth" until such time as they are no longer included here_
- pithekos: _keeping: 1 version of font "truth" until such time as they are no longer included here_

### Changes to process flow in this repo (run `npm install`):
- GraphiteTest(): Confirm the testFont has loaded, then useDetectRender
- If there is no Graphite then font_set is re-shaped to avoid bonked Awami.
- If Graphite is running then font_set is applied directly.